### PR TITLE
fix typings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,3 +17,4 @@ dts.js
 gulpfile.js
 karma.conf.js
 wakanda-solution/
+typings/

--- a/dist/wakanda-client.d.ts
+++ b/dist/wakanda-client.d.ts
@@ -1,6 +1,3 @@
-/// <reference path="../typings/browser.d.ts" />
-
-
 export {
   WakandaClient,
   CatalogBaseService,


### PR DESCRIPTION
Users must have in their tsconfig.json:
"lib": ["es5", "dom", "es2015.promise", "es2015.collection"]

and it should type-check.

Note, you probably should:
- update typescript version to 2.0
- remove the typings/ directory
- add needed lib or types block to tsconfig.json
